### PR TITLE
Add triggering from mavros

### DIFF
--- a/spinnaker_camera_driver/CMakeLists.txt
+++ b/spinnaker_camera_driver/CMakeLists.txt
@@ -7,9 +7,7 @@ project(spinnaker_camera_driver)
 
 find_package(catkin REQUIRED COMPONENTS
   camera_info_manager diagnostic_updater dynamic_reconfigure
-  image_exposure_msgs image_transport nodelet roscpp sensor_msgs
-  wfov_camera_msgs
-)
+  image_transport nodelet roscpp sensor_msgs)
 
 find_package(OpenCV REQUIRED)
 
@@ -18,7 +16,7 @@ generate_dynamic_reconfigure_options(
 )
 
 catkin_package(CATKIN_DEPENDS
-  image_exposure_msgs nodelet roscpp sensor_msgs wfov_camera_msgs
+  nodelet roscpp sensor_msgs
   DEPENDS OpenCV
 )
 

--- a/spinnaker_camera_driver/cfg/Spinnaker.cfg
+++ b/spinnaker_camera_driver/cfg/Spinnaker.cfg
@@ -238,6 +238,7 @@ trigger_overlap_modes = gen.enum([gen.const("Off", str_t, "Off", ""),
 
 gen.add("trigger_overlap_mode",                   str_t,    SensorLevels.RECONFIGURE_RUNNING,                "Trigger Overlap Modes",                                                                      "ReadOut",                       edit_method = trigger_overlap_modes)
 
+gen.add("trigger_delay", double_t, SensorLevels.RECONFIGURE_RUNNING, "Trigger Delay in microseconds (us)", 0.0, 0.0, 100000.0)
 
 
 # gen.add("enable_trigger_delay",                 bool_t,   SensorLevels.RECONFIGURE_RUNNING,                 "Whether Trigger Delay is active.",                                                           False)

--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
@@ -163,7 +163,7 @@ class SpinnakerCamera {
   */
   void grabImage(sensor_msgs::Image* image, const std::string& frame_id);
 
-  // Gets the exposure of the last image, in seconds (?)
+  // Gets the exposure of the last image, in microseconds.
   double getLastExposure();
 
   /*!

--- a/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
+++ b/spinnaker_camera_driver/include/spinnaker_camera_driver/SpinnakerCamera.h
@@ -163,6 +163,9 @@ class SpinnakerCamera {
   */
   void grabImage(sensor_msgs::Image* image, const std::string& frame_id);
 
+  // Gets the exposure of the last image, in seconds (?)
+  double getLastExposure();
+
   /*!
   * \brief Will set grabImage timeout for the camera.
   *

--- a/spinnaker_camera_driver/launch/camera.launch
+++ b/spinnaker_camera_driver/launch/camera.launch
@@ -10,7 +10,7 @@ Redistribution and use in source and binary forms, with or without modification,
 the following conditions are met:
  * Redistributions of source code must retain the above copyright notice, this list of conditions and the
    following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
    following disclaimer in the documentation and/or other materials provided with the distribution.
  * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or promote
    products derived from this software without specific prior written permission.
@@ -47,6 +47,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
       <!-- Use the camera_calibration package to create this file -->
       <param name="camera_info_url" if="$(arg calibrated)"
              value="file://$(env HOME)/.ros/camera_info/$(arg camera_serial).yaml" />
+      <param name="force_mavros_triggering" value="true" />
     </node>
 
     <node pkg="nodelet" type="nodelet" name="image_proc_debayer"

--- a/spinnaker_camera_driver/launch/camera_node.launch
+++ b/spinnaker_camera_driver/launch/camera_node.launch
@@ -6,7 +6,7 @@
   <arg name="calibrated" default="0" />
 
   <group ns="$(arg camera_name)">
-    <node name="spinnaker_camera_node" pkg="spinnaker_camera_driver" type="camera_node" clear_params="true">
+    <node name="spinnaker_camera_node" pkg="spinnaker_camera_driver" type="camera_node" clear_params="true" output="screen" >
       <param name="force_mavros_triggering" value="true" />
     </node>
   </group>

--- a/spinnaker_camera_driver/launch/camera_node.launch
+++ b/spinnaker_camera_driver/launch/camera_node.launch
@@ -1,0 +1,13 @@
+<launch>
+   <!-- Determine this using rosrun spinnaker_camera_driver list_cameras.
+       If not specified, defaults to first camera found. -->
+  <arg name="camera_name" default="camera" />
+  <arg name="camera_serial" default="0" />
+  <arg name="calibrated" default="0" />
+
+  <group ns="$(arg camera_name)">
+    <node name="spinnaker_camera_node" pkg="spinnaker_camera_driver" type="camera_node" clear_params="true">
+      <param name="force_mavros_triggering" value="true" />
+    </node>
+  </group>
+</launch>

--- a/spinnaker_camera_driver/package.xml
+++ b/spinnaker_camera_driver/package.xml
@@ -44,8 +44,6 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <depend>roscpp</depend>
   <depend>nodelet</depend>
   <depend>sensor_msgs</depend>
-  <depend>wfov_camera_msgs</depend>
-  <depend>image_exposure_msgs</depend>
   <depend>camera_info_manager</depend>
   <depend>image_transport</depend>
   <depend>dynamic_reconfigure</depend>

--- a/spinnaker_camera_driver/package.xml
+++ b/spinnaker_camera_driver/package.xml
@@ -51,6 +51,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <depend>dynamic_reconfigure</depend>
   <depend>diagnostic_updater</depend>
   <depend>opencv3</depend>
+  <depend>mavros_msgs</depend>
 
   <!-- Dependencies of libSpinnaker -->
   <depend>libusb-1.0-dev</depend>

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -239,7 +239,7 @@ void SpinnakerCamera::connect() {
       }
 
       // Configure chunk data - Enable Metadata
-      // SpinnakerCamera::ConfigureChunkData(*node_map_);
+      SpinnakerCamera::ConfigureChunkData(*node_map_);
     } catch (const Spinnaker::Exception& e) {
       throw std::runtime_error(
           "[SpinnakerCamera::connect] Failed to connect to camera. Error: " +

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -328,6 +328,8 @@ void SpinnakerCamera::grabImage(sensor_msgs::Image* image,
             "[SpinnakerCamera::grabImage] Image received from camera " +
             std::to_string(serial_) + " is incomplete.");
       } else {
+        image_metadata_ = image_ptr->GetChunkData();
+
         // Set Image Time Stamp
         // API description is wrong, this is NOT nanoseconds.
         image->header.stamp.fromNSec(image_ptr->GetTimeStamp() * 1000);
@@ -422,6 +424,10 @@ void SpinnakerCamera::grabImage(sensor_msgs::Image* image,
         "[SpinnakerCamera::grabImage] Not connected to the camera.");
   }
 }  // end grabImage
+
+double SpinnakerCamera::getLastExposure() {
+  return image_metadata_.GetExposureTime();
+}
 
 void SpinnakerCamera::setTimeout(const double& timeout) {
   timeout_ = static_cast<uint64_t>(std::round(timeout * 1000));

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -329,8 +329,9 @@ void SpinnakerCamera::grabImage(sensor_msgs::Image* image,
             std::to_string(serial_) + " is incomplete.");
       } else {
         // Set Image Time Stamp
-        image->header.stamp.sec = image_ptr->GetTimeStamp() * 1e-9;
-        image->header.stamp.nsec = image_ptr->GetTimeStamp();
+        // API description is wrong, this is NOT nanoseconds.
+        image->header.stamp.fromNSec(image_ptr->GetTimeStamp() * 1000);
+        image->header.seq = image_ptr->GetFrameID();
 
         // Check the bits per pixel.
         size_t bitsPerPixel = image_ptr->GetBitsPerPixel();

--- a/spinnaker_camera_driver/src/camera.cpp
+++ b/spinnaker_camera_driver/src/camera.cpp
@@ -97,6 +97,8 @@ void Camera::setNewConfiguration(const SpinnakerConfig& config,
     setProperty(node_map_, "TriggerSelector", config.trigger_selector);
     setProperty(node_map_, "TriggerActivation", config.trigger_activation_mode);
     setProperty(node_map_, "TriggerMode", config.enable_trigger);
+    setProperty(node_map_, "TriggerDelay",
+                static_cast<float>(config.trigger_delay));
 
     setProperty(node_map_, "LineSelector", config.line_selector);
     setProperty(node_map_, "LineMode", config.line_mode);

--- a/spinnaker_camera_driver/src/cm3.cpp
+++ b/spinnaker_camera_driver/src/cm3.cpp
@@ -92,6 +92,8 @@ void Cm3::setNewConfiguration(const SpinnakerConfig& config,
     setProperty(node_map_, "TriggerSelector", config.trigger_selector);
     setProperty(node_map_, "TriggerActivation", config.trigger_activation_mode);
     setProperty(node_map_, "TriggerMode", config.enable_trigger);
+    setProperty(node_map_, "TriggerDelay",
+                static_cast<float>(config.trigger_delay));
 
     setProperty(node_map_, "LineSelector", config.line_selector);
     setProperty(node_map_, "LineMode", config.line_mode);

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -616,7 +616,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
           }
 
           try {
-            sensor_msgs::Image::Ptr image;
+            sensor_msgs::Image::Ptr image(new sensor_msgs::Image);
             // Get the image from the camera library
             NODELET_DEBUG_ONCE(
                 "Starting a new grab from camera with serial {%d}.",

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -603,6 +603,8 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
                 "Starting a new grab from camera with serial {%d}.",
                 spinnaker_.getSerial());
             spinnaker_.grabImage(&wfov_image->image, frame_id_);
+            ROS_INFO("Got an image at sequence %lu and timestamp %f",
+                     wfov_image->header.seq, wfov_image->header.stamp);
 
             // Set other values
             wfov_image->header.frame_id = frame_id_;

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -755,8 +755,9 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
     if (delay < kMinExpectedDelay || delay > kMaxExpectedDelay) {
       ROS_ERROR(
           "[Mavros Triggering] Delay out of bounds! Actual delay: %f s, min: "
-          "%f s max: %f s",
+          "%f s max: %f s. Resetting triggering on next image.",
           delay, kMinExpectedDelay, kMaxExpectedDelay);
+      triggering_started_ = false;
     }
 
     *timestamp = it->second;

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -767,7 +767,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
 
   ros::Time shiftTimestampToMidExposure(const ros::Time& stamp,
                                         double exposure_us) {
-    ros::Time new_stamp = stamp + ros::Duration(exposure_us * 1e-6);
+    ros::Time new_stamp = stamp + ros::Duration(exposure_us * 1e-6 / 2.0);
     return new_stamp;
   }
 

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -339,8 +339,6 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
       // Publish topics using ImageTransport through camera_info_manager (gives
       // cool things like compression)
       it_.reset(new image_transport::ImageTransport(nh));
-      // image_transport::SubscriberStatusCallback cb =
-      //    boost::bind(&SpinnakerCameraNodelet::connectCb, this);
       it_pub_ = it_->advertiseCamera("image_raw", 5);
 
       // Set up diagnostics
@@ -682,7 +680,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
 
           catch (std::runtime_error& e) {
             NODELET_ERROR("%s", e.what());
-            // state = ERROR;
+            state = ERROR;
           }
 
           break;

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -421,7 +421,6 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
 
   void startMavrosTriggering() {
     // First subscribe to the messages so we don't miss any.'
-    ros::NodeHandle& nh = getMTNodeHandle();
     sequence_time_map_.clear();
     trigger_sequence_offset_ = 0;
 
@@ -614,7 +613,8 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
           } else if (force_mavros_triggering_ && triggering_started_ &&
                      trigger_sequence_offset_ > 20) {
             ROS_ERROR(
-                "Trigger sequence offset is too high at %d, "
+                "[Mavros Triggering] Trigger sequence offset is too high at "
+                "%d, "
                 "re-starting triggering.",
                 trigger_sequence_offset_);
             startMavrosTriggering();
@@ -631,8 +631,8 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
             double exposure_us = spinnaker_.getLastExposure();
 
             ROS_DEBUG(
-                "Got an image at sequence %lu and timestamp %f, exposure_us: "
-                "%f",
+                "[Mavros Triggering] Got an image at sequence %lu and "
+                "timestamp %f, exposure_us: %f",
                 image->header.seq, image->header.stamp.toSec(), exposure_us);
 
             bool should_publish = true;
@@ -745,7 +745,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
       return false;
     }
 
-    ROS_DEBUG("Remapped seq %d to %d, %f to %f", header.seq,
+    ROS_DEBUG("[Mavros Triggering] Remapped seq %d to %d, %f to %f", header.seq,
               header.seq + trigger_sequence_offset_, header.stamp.toSec(),
               it->second.toSec());
 

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -644,10 +644,12 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
                 spinnaker_.getSerial());
 
             spinnaker_.grabImage(&wfov_image->image, frame_id_);
+            double exposure = spinnaker_.getLastExposure();
 
-            ROS_INFO("Got an image at sequence %lu and timestamp %f",
-                     wfov_image->image.header.seq,
-                     wfov_image->image.header.stamp.toSec());
+            ROS_INFO(
+                "Got an image at sequence %lu and timestamp %f, exposure: %f",
+                wfov_image->image.header.seq,
+                wfov_image->image.header.stamp.toSec(), exposure);
 
             bool should_publish = true;
             if (force_mavros_triggering_) {


### PR DESCRIPTION
Other features
 - Rip out dependencies (msgs) on other point grey drivers
 - Make camera start up NOT when the first message is subscribed
 - Remove unused publishing
 - Add trigger_delay to dynamic config
 - Timestamping is done mid-exposure (so turn on exposure output from driver)

To turn on, set the param `force_mavros_triggering` to true.