### PR TITLE
Feature/keep rqt values

### DIFF
--- a/spinnaker_camera_driver/launch/camera_node.launch
+++ b/spinnaker_camera_driver/launch/camera_node.launch
@@ -1,13 +1,13 @@
+<?xml version="1.0"?>
 <launch>
    <!-- Determine this using rosrun spinnaker_camera_driver list_cameras.
        If not specified, defaults to first camera found. -->
   <arg name="camera_name" default="camera" />
-  <arg name="camera_serial" default="0" />
-  <arg name="calibrated" default="0" />
+  <arg name="force_mavros_triggering" default="true" />
 
   <group ns="$(arg camera_name)">
     <node name="spinnaker_camera_node" pkg="spinnaker_camera_driver" type="camera_node" clear_params="true" output="screen" >
-      <param name="force_mavros_triggering" value="true" />
+      <param name="force_mavros_triggering" value="$(arg force_mavros_triggering)" />
     </node>
   </group>
 </launch>

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -756,6 +756,8 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
           "[Mavros Triggering] Delay out of bounds! Actual delay: %f s, min: "
           "%f s max: %f s",
           delay, kMinExpectedDelay, kMaxExpectedDelay);
+      startMavrosTriggering();
+      return false;
     }
 
     *timestamp = it->second;

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -391,6 +391,9 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
       // Here are the triggering settings.
       pnh.param("force_mavros_triggering", force_mavros_triggering_, false);
       ROS_INFO("Force mavros triggering: %d", force_mavros_triggering_);
+      double imu_time_offset_s;
+      pnh.param("imu_time_offset_s", imu_time_offset_s, 0.0);
+      imu_time_offset_ = ros::Duration(imu_time_offset_s);
 
       // Set up all the stuff for mavros triggering.
       if (force_mavros_triggering_) {
@@ -651,6 +654,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
               } else {
                 image->header.stamp =
                     shiftTimestampToMidExposure(new_stamp, exposure_us);
+                image->header.stamp += imu_time_offset_;
               }
             }
 
@@ -712,6 +716,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
                                             kFromImageQueue)) {
       image_queue_->header.stamp =
           shiftTimestampToMidExposure(new_stamp, image_queue_exposure_us_);
+      image_queue_->header.stamp += imu_time_offset_;
       it_pub_.publish(image_queue_, ci_);
       image_queue_.reset();
       ROS_WARN_THROTTLE(60, "Publishing delayed image.");
@@ -846,6 +851,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
   double image_queue_exposure_us_;
   bool first_image_;
   bool triggering_started_;
+  ros::Duration imu_time_offset_;
 
   /// Configuration:
   spinnaker_camera_driver::SpinnakerConfig config_;

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -328,7 +328,6 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
               &spinnaker_camera_driver::SpinnakerCameraNodelet::paramCallback,
               this, _1, _2);
       srv_->setCallback(f);
-      srv_->getConfig(config_);
 
       // Start the camera info manager and attempt to load any configurations
       std::stringstream cinfo_name;
@@ -429,7 +428,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
       mavros_msgs::CommandTriggerControl req;
       req.request.trigger_enable = true;
       // This is NOT integration time, this is actually the sequence reset.
-      req.request.integration_time = 1.0;
+      req.request.cycle_time = 1.0;
 
       ros::service::call(mavros_trigger_service, req);
 

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -328,7 +328,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
               &spinnaker_camera_driver::SpinnakerCameraNodelet::paramCallback,
               this, _1, _2);
       srv_->setCallback(f);
-      srv_->getConfigDefault(config_);
+      srv_->getConfig(config_);
 
       // Start the camera info manager and attempt to load any configurations
       std::stringstream cinfo_name;

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -414,7 +414,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
 
     ros::NodeHandle& nh = getMTNodeHandle();
     cam_imu_sub_ =
-        nh.subscribe("/mavros/cam_imu_sync/cam_imu_stamp", 100,
+        nh.subscribe("mavros/cam_imu_sync/cam_imu_stamp", 100,
                      &SpinnakerCameraNodelet::camImuStampCallback, this);
   }
 
@@ -423,7 +423,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
     sequence_time_map_.clear();
     trigger_sequence_offset_ = 0;
 
-    const std::string mavros_trigger_service = "/mavros/cmd/trigger_control";
+    const std::string mavros_trigger_service = "mavros/cmd/trigger_control";
     if (ros::service::exists(mavros_trigger_service, false)) {
       mavros_msgs::CommandTriggerControl req;
       req.request.trigger_enable = true;


### PR DESCRIPTION
Removed unused values from launchfile
Removed absolute paths so it can find mavros in a group
Removed overwriting current values with defaults so values from launchfile are used
Updated name of msg to work with new mavros