### PR TITLE
Feature/mono image

### DIFF
--- a/spinnaker_camera_driver/package.xml
+++ b/spinnaker_camera_driver/package.xml
@@ -49,6 +49,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <depend>dynamic_reconfigure</depend>
   <depend>diagnostic_updater</depend>
   <depend>opencv3</depend>
+
   <depend>mavros_msgs</depend>
 
   <!-- Dependencies of libSpinnaker -->

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -406,7 +406,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
     // Set up the camera to listen to triggers.
     config_.enable_trigger = "On";
     config_.trigger_activation_mode = "FallingEdge";
-    config_.trigger_source = "Line3";
+    config_.trigger_source = "Line2";
     paramCallback(config_, 0);
     srv_->updateConfig(config_);
     // Set these for now...

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -405,7 +405,7 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
   void setupMavrosTriggering() {
     // Set up the camera to listen to triggers.
     config_.enable_trigger = "On";
-    config_.trigger_activation_mode = "FallingEdge";
+    config_.trigger_activation_mode = "RisingEdge";
     config_.trigger_source = "Line2";
     paramCallback(config_, 0);
     srv_->updateConfig(config_);

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -686,7 +686,9 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
             // Publish the message using standard image transport
             if (should_publish) {
               it_pub_.publish(image, ci_);
-              publishMonoImage(image, ci_);
+              if(publish_mono_) {
+                publishMonoImage(image, ci_);
+              }
             }
           } catch (CameraTimeoutException& e) {
             NODELET_WARN("%s", e.what());
@@ -726,7 +728,9 @@ class SpinnakerCameraNodelet : public nodelet::Nodelet {
           shiftTimestampToMidExposure(new_stamp, image_queue_exposure_us_);
       image_queue_->header.stamp += imu_time_offset_;
       it_pub_.publish(image_queue_, ci_);
-      publishMonoImage(image_queue_, ci_);
+      if(publish_mono_) {
+        publishMonoImage(image_queue_, ci_);
+      }
       image_queue_.reset();
       ROS_WARN_THROTTLE(60, "Publishing delayed image.");
     }


### PR DESCRIPTION
Pull request of changes found on flybook4 and the added mono image publishers.

We had issues when we were running the camera on penguin in color mode and in parallel using image_proc to convert the color image into a mono image for rovio. Essentially, image_proc lost frames (CPU overload?) and rovio went crazy because of that.

To mitigate this for use cases where we need color images (e.g. reconstruction), I added a second image publisher to the spinnaker driver that publishes a mono image directly. If the parameter "publish_mono" is true, and the image_format_color_coding is set to e.g. RGB8packed, the images are used in the following way:

image_raw is the color image (here , format RGB8packed)
image_mono_raw is always a mono image with mono8 format for rovio

@raghavkhanna @inkyusa  does that interfere with the way you use the camera? (See changes in triggering  line/edge)


