### PR TITLE
Clean-up after trigger source switching (mavros -> versavis)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "image_numbered_msgs"]
-	path = image_numbered_msgs
-	url = https://github.com/ethz-asl/image_numbered_msgs.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "image_numbered_msgs"]
+	path = image_numbered_msgs
+	url = https://github.com/ethz-asl/image_numbered_msgs.git

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ Tip when installing spinnaker: Only install the actual library and not libspinvi
 To do so, modify the install script (install_spinnaker.sh) to not include any of the spinvideo/spinview packages (on line 38 and following)
 
 ## How to install
-https://eu.ptgrey.com/support/downloads/11048/  
+* Get the Spinnaker SDK from https://www.flir.com/products/spinnaker-sdk/.<br />
+Direct link to most recent SpinnakerSDK for Linux: https://flir.app.boxcn.net/v/SpinnakerSDK/folder/69083919457.
+
+* Follow the instructions in the provided REAMDE to install the Spinnaker SDK on your system.
+
+* The Spinnaker SDK depends on libunwind8:
 ```sudo apt install libunwind8-dev```
-* package depends on [mavros_msgs](git@github.com:ethz-asl/mavros.git)
+* The spinnaker_camera_driver package (part of this repository) depends on [image_numbered_msgs](https://github.com/ethz-asl/image_numbered_msgs.git)
+
 ### Increasing USB memory buffer
 From [Pointgrey](https://www.ptgrey.com/tan/10685#ConfiguringUSBFS)
 

--- a/spinnaker_camera_driver/CMakeLists.txt
+++ b/spinnaker_camera_driver/CMakeLists.txt
@@ -7,7 +7,7 @@ project(spinnaker_camera_driver)
 
 find_package(catkin REQUIRED COMPONENTS
   camera_info_manager diagnostic_updater dynamic_reconfigure
-  image_transport nodelet roscpp sensor_msgs)
+  image_transport nodelet roscpp sensor_msgs image_numbered_msgs)
 
 find_package(OpenCV REQUIRED)
 
@@ -16,7 +16,7 @@ generate_dynamic_reconfigure_options(
 )
 
 catkin_package(CATKIN_DEPENDS
-  nodelet roscpp sensor_msgs
+  nodelet roscpp sensor_msgs image_numbered_msgs
   DEPENDS OpenCV
 )
 

--- a/spinnaker_camera_driver/package.xml
+++ b/spinnaker_camera_driver/package.xml
@@ -48,6 +48,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <depend>image_transport</depend>
   <depend>dynamic_reconfigure</depend>
   <depend>diagnostic_updater</depend>
+  <depend>image_numbered_msgs</depend>
   <depend>opencv3</depend>
 
   <!-- Dependencies of libSpinnaker -->


### PR DESCRIPTION
The merged PR https://github.com/ethz-asl/flir_camera_driver/pull/14 switched the triggering from mavros to versavis, which is kind of a big change :)
The goal of this PR is to clean up the implications:

- [x] Update Readme
- [x] Fix CMakeLists.txt & package.xml
- [ ] Include [image_numbered_msgs](https://github.com/ethz-asl/versavis/blob/master/image_numbered_msgs/msg/ImageNumbered.msg)? (Or is there another/better way?
- [ ] ...

Other thoughts?